### PR TITLE
chore: import repository git@github.com:property-xyz/crontab-sitemap-builder.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -9,6 +9,7 @@ spec:
     providerKind: github
     repositories:
     - name: cron-postcode-emitter
+    - name: crontab-sitemap-builder
     - name: data-avm-service
     - name: data-council-tax-service
     - name: data-crime-stats

--- a/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
@@ -8,6 +8,7 @@ data:
     in_repo_config:
       enabled:
         property-xyz/cron-postcode-emitter: true
+        property-xyz/crontab-sitemap-builder: true
         property-xyz/data-avm-service: true
         property-xyz/data-council-tax-service: true
         property-xyz/data-crime-stats: true
@@ -47,6 +48,7 @@ data:
         skip-unknown-contexts: false
       merge_method:
         property-xyz/cron-postcode-emitter: merge
+        property-xyz/crontab-sitemap-builder: merge
         property-xyz/data-avm-service: merge
         property-xyz/data-council-tax-service: merge
         property-xyz/data-crime-stats: merge
@@ -88,6 +90,7 @@ data:
         - property-xyz/prod_platform-cluster
         - property-xyz/stage_platform-cluster
         - property-xyz/cron-postcode-emitter
+        - property-xyz/crontab-sitemap-builder
         - property-xyz/data-avm-service
         - property-xyz/data-council-tax-service
         - property-xyz/data-crime-stats
@@ -125,6 +128,7 @@ data:
         - property-xyz/prod_platform-cluster
         - property-xyz/stage_platform-cluster
         - property-xyz/cron-postcode-emitter
+        - property-xyz/crontab-sitemap-builder
         - property-xyz/data-avm-service
         - property-xyz/data-council-tax-service
         - property-xyz/data-crime-stats

--- a/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
@@ -20,6 +20,10 @@ data:
       require_self_approval: true
     - lgtm_acts_as_approve: true
       repos:
+      - property-xyz/crontab-sitemap-builder
+      require_self_approval: true
+    - lgtm_acts_as_approve: true
+      repos:
       - property-xyz/data-avm-service
       require_self_approval: true
     - lgtm_acts_as_approve: true
@@ -133,6 +137,11 @@ data:
           name: plugins
     external_plugins:
       property-xyz/cron-postcode-emitter:
+      - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
+        name: cd-indicators
+      - endpoint: http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events
+        name: lighthouse-webui-plugin
+      property-xyz/crontab-sitemap-builder:
       - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
         name: cd-indicators
       - endpoint: http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events
@@ -278,6 +287,22 @@ data:
     owners: {}
     plugins:
       property-xyz/cron-postcode-emitter:
+      - approve
+      - assign
+      - blunderbuss
+      - help
+      - hold
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - trigger
+      - wip
+      - heart
+      - cat
+      - dog
+      - pony
+      property-xyz/crontab-sitemap-builder:
       - approve
       - assign
       - blunderbuss
@@ -746,6 +771,9 @@ data:
       trusted_org: todo
     - repos:
       - property-xyz/cron-postcode-emitter
+      trusted_org: todo
+    - repos:
+      - property-xyz/crontab-sitemap-builder
       trusted_org: todo
     - repos:
       - property-xyz/data-avm-service

--- a/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: lighthouse-foghorn
       annotations:
-        jenkins-x.io/hash: '0745397a66bbee5e4c416cf716221338b9f87816447173fd3e25438a88755586'
+        jenkins-x.io/hash: 'f2bf545ace8655b0e2e6a72eff4bf2f04e22fd9226181325d9e6cccb3fbb5164'
     spec:
       serviceAccountName: lighthouse-foghorn
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         ad.datadoghq.com/keeper.logs: '[{"source":"lighthouse","service":"keeper"}]'
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: '0745397a66bbee5e4c416cf716221338b9f87816447173fd3e25438a88755586'
+        jenkins-x.io/hash: 'f2bf545ace8655b0e2e6a72eff4bf2f04e22fd9226181325d9e6cccb3fbb5164'
       labels:
         app: lighthouse-keeper
     spec:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: lighthouse-tekton-controller
-      annotations: {jenkins-x.io/hash: '0745397a66bbee5e4c416cf716221338b9f87816447173fd3e25438a88755586'}
+      annotations: {jenkins-x.io/hash: 'f2bf545ace8655b0e2e6a72eff4bf2f04e22fd9226181325d9e6cccb3fbb5164'}
     spec:
       serviceAccountName: lighthouse-tekton-controller
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: '0745397a66bbee5e4c416cf716221338b9f87816447173fd3e25438a88755586'
+        jenkins-x.io/hash: 'f2bf545ace8655b0e2e6a72eff4bf2f04e22fd9226181325d9e6cccb3fbb5164'
     spec:
       serviceAccountName: lighthouse-webhooks
       containers:

--- a/config-root/namespaces/jx/source-repositories/property-xyz-crontab-sitemap-builder.yaml
+++ b/config-root/namespaces/jx/source-repositories/property-xyz-crontab-sitemap-builder.yaml
@@ -1,0 +1,22 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: property-xyz
+    provider: github
+    repository: crontab-sitemap-builder
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  name: property-xyz-crontab-sitemap-builder
+  namespace: jx
+spec:
+  httpCloneURL: https://github.com/property-xyz/crontab-sitemap-builder.git
+  org: property-xyz
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: crontab-sitemap-builder
+  scheduler:
+    kind: ""
+    name: in-repo
+  url: https://github.com/property-xyz/crontab-sitemap-builder


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
